### PR TITLE
Add SequentialExecutorService that assists publishing for Cloud Pub/Sub

### DIFF
--- a/.kokoro/continuous/bigtableadmin-it.cfg
+++ b/.kokoro/continuous/bigtableadmin-it.cfg
@@ -8,7 +8,7 @@ env_vars: {
 
 env_vars: {
     key: "INTEGRATION_TEST_ARGS"
-    value: "google-cloud-clients/google-cloud-bigtable-admin -Dbigtable.instance=projects/gcloud-devel/instances/google-cloud-bigtable"
+    value: "google-cloud-clients/google-cloud-bigtable-admin -Dbigtable.project=gcloud-devel -Dbigtable.instance=google-cloud-bigtable"
 }
 
 env_vars: {

--- a/.kokoro/nightly/bigtableadmin-it.cfg
+++ b/.kokoro/nightly/bigtableadmin-it.cfg
@@ -8,7 +8,7 @@ env_vars: {
 
 env_vars: {
     key: "INTEGRATION_TEST_ARGS"
-    value: "google-cloud-clients/google-cloud-bigtable-admin -Dbigtable.instance=projects/gcloud-devel/instances/google-cloud-bigtable"
+    value: "google-cloud-clients/google-cloud-bigtable-admin -Dbigtable.project=gcloud-devel -Dbigtable.instance=google-cloud-bigtable"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/bigtableadmin-it.cfg
+++ b/.kokoro/presubmit/bigtableadmin-it.cfg
@@ -8,7 +8,7 @@ env_vars: {
 
 env_vars: {
     key: "INTEGRATION_TEST_ARGS"
-    value: "google-cloud-clients/google-cloud-bigtable-admin -Dbigtable.instance=projects/gcloud-devel/instances/google-cloud-bigtable"
+    value: "google-cloud-clients/google-cloud-bigtable-admin -Dbigtable.project=gcloud-devel -Dbigtable.instance=google-cloud-bigtable"
 }
 
 env_vars: {

--- a/TESTING.md
+++ b/TESTING.md
@@ -79,7 +79,8 @@ To run the tests:
     created earlier. Example:
     ```shell
     mvn verify -am -pl google-cloud-bigtable-admin \
-      -Dbigtable.instance=projects/my-project/instances/my-instance
+      -Dbigtable.project=my-project
+      -Dbigtable.instance=my-instance
     ```
 
 ### Testing code that uses Compute

--- a/google-api-grpc/proto-google-cloud-securitycenter-v1beta1/src/main/java/com/google/cloud/securitycenter/v1beta1/Source.java
+++ b/google-api-grpc/proto-google-cloud-securitycenter-v1beta1/src/main/java/com/google/cloud/securitycenter/v1beta1/Source.java
@@ -164,8 +164,8 @@ public final class Source extends com.google.protobuf.GeneratedMessageV3
    *
    *
    * <pre>
-   * The source’s display name.
-   * A source’s display name must be unique amongst its siblings, for example,
+   * The source's display name.
+   * A source's display name must be unique amongst its siblings, for example,
    * two sources with the same parent can't share the same display name.
    * The display name must start and end with a letter or digit, may contain
    * letters, digits, spaces, hyphens, and underscores, and can be no longer
@@ -190,8 +190,8 @@ public final class Source extends com.google.protobuf.GeneratedMessageV3
    *
    *
    * <pre>
-   * The source’s display name.
-   * A source’s display name must be unique amongst its siblings, for example,
+   * The source's display name.
+   * A source's display name must be unique amongst its siblings, for example,
    * two sources with the same parent can't share the same display name.
    * The display name must start and end with a letter or digit, may contain
    * letters, digits, spaces, hyphens, and underscores, and can be no longer
@@ -733,8 +733,8 @@ public final class Source extends com.google.protobuf.GeneratedMessageV3
      *
      *
      * <pre>
-     * The source’s display name.
-     * A source’s display name must be unique amongst its siblings, for example,
+     * The source's display name.
+     * A source's display name must be unique amongst its siblings, for example,
      * two sources with the same parent can't share the same display name.
      * The display name must start and end with a letter or digit, may contain
      * letters, digits, spaces, hyphens, and underscores, and can be no longer
@@ -759,8 +759,8 @@ public final class Source extends com.google.protobuf.GeneratedMessageV3
      *
      *
      * <pre>
-     * The source’s display name.
-     * A source’s display name must be unique amongst its siblings, for example,
+     * The source's display name.
+     * A source's display name must be unique amongst its siblings, for example,
      * two sources with the same parent can't share the same display name.
      * The display name must start and end with a letter or digit, may contain
      * letters, digits, spaces, hyphens, and underscores, and can be no longer
@@ -785,8 +785,8 @@ public final class Source extends com.google.protobuf.GeneratedMessageV3
      *
      *
      * <pre>
-     * The source’s display name.
-     * A source’s display name must be unique amongst its siblings, for example,
+     * The source's display name.
+     * A source's display name must be unique amongst its siblings, for example,
      * two sources with the same parent can't share the same display name.
      * The display name must start and end with a letter or digit, may contain
      * letters, digits, spaces, hyphens, and underscores, and can be no longer
@@ -809,8 +809,8 @@ public final class Source extends com.google.protobuf.GeneratedMessageV3
      *
      *
      * <pre>
-     * The source’s display name.
-     * A source’s display name must be unique amongst its siblings, for example,
+     * The source's display name.
+     * A source's display name must be unique amongst its siblings, for example,
      * two sources with the same parent can't share the same display name.
      * The display name must start and end with a letter or digit, may contain
      * letters, digits, spaces, hyphens, and underscores, and can be no longer
@@ -830,8 +830,8 @@ public final class Source extends com.google.protobuf.GeneratedMessageV3
      *
      *
      * <pre>
-     * The source’s display name.
-     * A source’s display name must be unique amongst its siblings, for example,
+     * The source's display name.
+     * A source's display name must be unique amongst its siblings, for example,
      * two sources with the same parent can't share the same display name.
      * The display name must start and end with a letter or digit, may contain
      * letters, digits, spaces, hyphens, and underscores, and can be no longer

--- a/google-api-grpc/proto-google-cloud-securitycenter-v1beta1/src/main/java/com/google/cloud/securitycenter/v1beta1/SourceOrBuilder.java
+++ b/google-api-grpc/proto-google-cloud-securitycenter-v1beta1/src/main/java/com/google/cloud/securitycenter/v1beta1/SourceOrBuilder.java
@@ -39,8 +39,8 @@ public interface SourceOrBuilder
    *
    *
    * <pre>
-   * The source’s display name.
-   * A source’s display name must be unique amongst its siblings, for example,
+   * The source's display name.
+   * A source's display name must be unique amongst its siblings, for example,
    * two sources with the same parent can't share the same display name.
    * The display name must start and end with a letter or digit, may contain
    * letters, digits, spaces, hyphens, and underscores, and can be no longer
@@ -55,8 +55,8 @@ public interface SourceOrBuilder
    *
    *
    * <pre>
-   * The source’s display name.
-   * A source’s display name must be unique amongst its siblings, for example,
+   * The source's display name.
+   * A source's display name must be unique amongst its siblings, for example,
    * two sources with the same parent can't share the same display name.
    * The display name must start and end with a letter or digit, may contain
    * letters, digits, spaces, hyphens, and underscores, and can be no longer

--- a/google-api-grpc/proto-google-cloud-securitycenter-v1beta1/src/main/proto/google/cloud/securitycenter/v1beta1/source.proto
+++ b/google-api-grpc/proto-google-cloud-securitycenter-v1beta1/src/main/proto/google/cloud/securitycenter/v1beta1/source.proto
@@ -34,8 +34,8 @@ message Source {
   // "organizations/123/sources/456"
   string name = 1;
 
-  // The source’s display name.
-  // A source’s display name must be unique amongst its siblings, for example,
+  // The source's display name.
+  // A source's display name must be unique amongst its siblings, for example,
   // two sources with the same parent can't share the same display name.
   // The display name must start and end with a letter or digit, may contain
   // letters, digits, spaces, hyphens, and underscores, and can be no longer

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettings.java
@@ -26,14 +26,13 @@ import javax.annotation.Nullable;
 /**
  * Settings class to configure an instance of {@link BigtableInstanceAdminClient}.
  *
- * <p>It must be configured with a {@link ProjectName} and can be used to change default RPC
- * settings.
+ * <p>It must be configured with a project id and can be used to change default RPC settings.
  *
  * <p>Example usage:
  *
  * <pre>{@code
  * BigtableInstanceAdminSettings.Builder settingsBuilder = BigtableInstanceAdminSettings.newBuilder()
- *  .setProjectName(ProjectName.of("my-project"));
+ *  .setProjectId("my-project");
  *
  * settingsBuilder.stubSettings().createInstanceSettings()
  *   .setRetrySettings(
@@ -45,21 +44,32 @@ import javax.annotation.Nullable;
  * }</pre>
  */
 public final class BigtableInstanceAdminSettings {
-  private final ProjectName projectName;
+  private final String projectId;
   private final BigtableInstanceAdminStubSettings stubSettings;
 
   private BigtableInstanceAdminSettings(Builder builder) throws IOException {
-    Preconditions.checkNotNull(builder.projectName, "ProjectName must be set");
+    Preconditions.checkNotNull(builder.projectId, "Project ud must be set");
     Verify.verifyNotNull(builder.stubSettings, "stubSettings should never be null");
 
-    this.projectName = builder.projectName;
+    this.projectId = builder.projectId;
     this.stubSettings = builder.stubSettings.build();
   }
 
-  /** Gets the anme of the project whose instances the client will manager. */
+  /** Gets the id of the project whose instances the client will manage. */
   @Nonnull
-  public ProjectName getProjectName() {
-    return projectName;
+  public String getProjectId() {
+    return projectId;
+  }
+
+  /**
+   * Gets the name of the project whose instances the client will manager.
+   *
+   * @deprecated Please use {@link #getProjectId()}.
+   */
+  @Deprecated
+  @Nonnull
+  public com.google.bigtable.admin.v2.ProjectName getProjectName() {
+    return ProjectName.of(projectId);
   }
 
   /** Gets the underlying RPC settings. */
@@ -80,7 +90,7 @@ public final class BigtableInstanceAdminSettings {
 
   /** Builder for BigtableInstanceAdminSettings. */
   public static final class Builder {
-    @Nullable private ProjectName projectName;
+    @Nullable private String projectId;
     private final BigtableInstanceAdminStubSettings.Builder stubSettings;
 
     private Builder() {
@@ -88,21 +98,45 @@ public final class BigtableInstanceAdminSettings {
     }
 
     private Builder(BigtableInstanceAdminSettings settings) {
-      this.projectName = settings.projectName;
+      this.projectId = settings.projectId;
       this.stubSettings = settings.stubSettings.toBuilder();
     }
 
-    /** Sets the name of instance whose tables the client will manage. */
-    public Builder setProjectName(@Nonnull ProjectName projectName) {
-      Preconditions.checkNotNull(projectName);
-      this.projectName = projectName;
+    /** Sets the id of the project whose instances the client will manage. */
+    public Builder setProjectId(@Nonnull String projectId) {
+      Preconditions.checkNotNull(projectId);
+      this.projectId = projectId;
       return this;
     }
 
-    /** Gets the name of the project whose instances the client will manage. */
+    /** Gets the id of the project whose instances the client will manage. */
+    @Nullable
+    public String getProjectId() {
+      return projectId;
+    }
+
+    /**
+     * Sets the name of instance whose tables the client will manage.
+     *
+     * @deprecated Please use {@link #setProjectId(String)}.
+     */
+    @Deprecated
+    public Builder setProjectName(@Nonnull com.google.bigtable.admin.v2.ProjectName projectName) {
+      return setProjectId(projectName.getProject());
+    }
+
+    /**
+     * Gets the name of the project whose instances the client will manage.
+     *
+     * @deprecated Please use {@link #getProjectId()}.
+     */
+    @Deprecated
     @Nullable
     public ProjectName getProjectName() {
-      return projectName;
+      if (projectId != null) {
+        return ProjectName.of(projectId);
+      }
+      return null;
     }
 
     /**

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettings.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.admin.v2;
 
-import com.google.bigtable.admin.v2.InstanceName;
 import com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStubSettings;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
@@ -26,14 +25,14 @@ import javax.annotation.Nullable;
 /**
  * Settings class to configure an instance of {@link BigtableTableAdminClient}.
  *
- * <p>It must be configured with an {@link InstanceName} and can be used to change default RPC
- * settings.
+ * <p>It must be configured with a project id and instance id.
  *
  * <p>Example usage:
  *
  * <pre>{@code
  * BigtableTableAdminSettings.Builder tableAdminSettingsBuilder = BigtableTableAdminSettings.newBuilder()
- *   .setInstanceName(InstanceName.of("my-project", "my-instance");
+ *   .setProjectId("my-project")
+ *   .setInstanceId("my-instance");
  *
  * tableAdminSettingsBuilder.stubSettings().createTableSettings()
  *   .setRetrySettings(
@@ -45,20 +44,36 @@ import javax.annotation.Nullable;
  * }</pre>
  */
 public final class BigtableTableAdminSettings {
-  private final InstanceName instanceName;
+  private final String projectId;
+  private final String instanceId;
   private final BigtableTableAdminStubSettings stubSettings;
 
   private BigtableTableAdminSettings(Builder builder) throws IOException {
-    this.instanceName =
-        Preconditions.checkNotNull(builder.instanceName, "InstanceName must be set");
+    this.projectId = Preconditions.checkNotNull(builder.projectId, "Project id must be set");
+    this.instanceId = Preconditions.checkNotNull(builder.instanceId, "Instance id must be set");
     this.stubSettings =
         Verify.verifyNotNull(builder.stubSettings, "stubSettings should never be null").build();
   }
 
-  /** Gets the name of instance whose tables the client will manage. */
+  /** Gets the project id of instance whose tables the client will manage. */
+  public String getProjectId() {
+    return projectId;
+  }
+
+  /** Gets the instance id whose tables the client will manage. */
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  /**
+   * Gets the name of instance whose tables the client will manage.
+   *
+   * @deprecated Please use {@link #getProjectId()} and {@link #getInstanceId()}.
+   */
+  @Deprecated
   @Nonnull
-  public InstanceName getInstanceName() {
-    return instanceName;
+  public com.google.bigtable.admin.v2.InstanceName getInstanceName() {
+    return com.google.bigtable.admin.v2.InstanceName.of(projectId, instanceId);
   }
 
   /** Gets the underlying RPC settings. */
@@ -78,7 +93,8 @@ public final class BigtableTableAdminSettings {
 
   /** Builder for BigtableTableAdminSettings. */
   public static final class Builder {
-    @Nullable private InstanceName instanceName;
+    @Nullable private String projectId;
+    @Nullable private String instanceId;
     private final BigtableTableAdminStubSettings.Builder stubSettings;
 
     private Builder() {
@@ -86,21 +102,63 @@ public final class BigtableTableAdminSettings {
     }
 
     private Builder(BigtableTableAdminSettings settings) {
-      this.instanceName = settings.instanceName;
+      this.projectId = settings.projectId;
+      this.instanceId = settings.instanceId;
       this.stubSettings = settings.stubSettings.toBuilder();
     }
 
-    /** Sets the name of instance whose tables the client will manage. */
-    public Builder setInstanceName(@Nonnull InstanceName instanceName) {
-      Preconditions.checkNotNull(instanceName);
-      this.instanceName = instanceName;
+    /** Sets the project id of the instance whose tables the client will manage. */
+    public Builder setProjectId(@Nullable String projectId) {
+      Preconditions.checkNotNull(projectId);
+      this.projectId = projectId;
       return this;
     }
 
-    /** Gets the name of instance whose tables the client will manage. */
+    /** Gets the project id of the instance whose tables the client will manage. */
     @Nullable
-    public InstanceName getInstanceName() {
-      return instanceName;
+    public String getProjectId() {
+      return projectId;
+    }
+
+    /** Sets the instance id of the instance whose tables the client will manage. */
+    public Builder setInstanceId(@Nullable String instanceId) {
+      Preconditions.checkNotNull(instanceId);
+      this.instanceId = instanceId;
+      return this;
+    }
+
+    /** Gets the instance id of the instance whose tables the client will manage. */
+    @Nullable
+    public String getInstanceId() {
+      return instanceId;
+    }
+
+    /**
+     * Sets the name of instance whose tables the client will manage.
+     *
+     * @deprecated Please use {@link #setProjectId(String)} and {@link #setInstanceId(String)}.
+     */
+    @Deprecated
+    public Builder setInstanceName(
+        @Nonnull com.google.bigtable.admin.v2.InstanceName instanceName) {
+      Preconditions.checkNotNull(instanceName);
+      this.projectId = instanceName.getProject();
+      this.instanceId = instanceName.getInstance();
+      return this;
+    }
+
+    /**
+     * Gets the name of instance whose tables the client will manage.
+     *
+     * @deprecated Please use {@link #getProjectId()} and {@link #getInstanceId()}.
+     */
+    @Deprecated
+    @Nullable
+    public com.google.bigtable.admin.v2.InstanceName getInstanceName() {
+      if (projectId != null && instanceId != null) {
+        return com.google.bigtable.admin.v2.InstanceName.of(projectId, instanceId);
+      }
+      return null;
     }
 
     /**

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/internal/NameUtil.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/internal/NameUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2.internal;
+
+import com.google.api.core.InternalApi;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Internal helper to compose full resource names.
+ *
+ * <p>This class is considered an internal implementation detail and not meant to be used by
+ * applications.
+ */
+@InternalApi
+public class NameUtil {
+  private static final Pattern TABLE_PATTERN =
+      Pattern.compile("projects/([^/]+)/instances/([^/]+)/tables/([^/]+)");
+  private static final Pattern LOCATION_PATTERN =
+      Pattern.compile("projects/([^/]+)/locations/([^/]+)");
+
+  public static String formatProjectName(String projectId) {
+    return "projects/" + projectId;
+  }
+
+  public static String formatInstanceName(String projectId, String instanceId) {
+    return formatProjectName(projectId) + "/instances/" + instanceId;
+  }
+
+  public static String formatTableName(String projectId, String instanceId, String tableId) {
+    return formatInstanceName(projectId, instanceId) + "/tables/" + tableId;
+  }
+
+  public static String formatLocationName(String projectId, String zone) {
+    return formatProjectName(projectId) + "/locations/" + zone;
+  }
+
+  public static String extractTableIdFromTableName(String fullTableName) {
+    Matcher matcher = TABLE_PATTERN.matcher(fullTableName);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException("Invalid table name: " + fullTableName);
+    }
+    return matcher.group(3);
+  }
+
+  public static String extractZoneIdFromLocationName(String fullLocationName) {
+    Matcher matcher = LOCATION_PATTERN.matcher(fullLocationName);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException("Invalid location name: " + fullLocationName);
+    }
+    return matcher.group(2);
+  }
+
+  public static String formatClusterName(String projectId, String instanceId, String clusterId) {
+    return formatInstanceName(projectId, instanceId) + "/clusters/" + clusterId;
+  }
+
+  public static String formatAppProfileName(
+      String projectId, String instanceId, String appProfileId) {
+    return formatInstanceName(projectId, instanceId) + "/appProfiles/" + appProfileId;
+  }
+}

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateAppProfileRequest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateAppProfileRequest.java
@@ -16,8 +16,7 @@
 package com.google.cloud.bigtable.admin.v2.models;
 
 import com.google.api.core.InternalApi;
-import com.google.bigtable.admin.v2.InstanceName;
-import com.google.bigtable.admin.v2.ProjectName;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import com.google.cloud.bigtable.admin.v2.models.AppProfile.MultiClusterRoutingPolicy;
 import com.google.cloud.bigtable.admin.v2.models.AppProfile.RoutingPolicy;
 import com.google.cloud.bigtable.admin.v2.models.AppProfile.SingleClusterRoutingPolicy;
@@ -98,9 +97,9 @@ public final class CreateAppProfileRequest {
    * not meant to be used by applications.
    */
   @InternalApi
-  public com.google.bigtable.admin.v2.CreateAppProfileRequest toProto(ProjectName projectName) {
-    InstanceName name = InstanceName.of(projectName.getProject(), instanceId);
+  public com.google.bigtable.admin.v2.CreateAppProfileRequest toProto(String projectId) {
+    String name = NameUtil.formatInstanceName(projectId, instanceId);
 
-    return proto.setParent(name.toString()).build();
+    return proto.setParent(name).build();
   }
 }

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateClusterRequest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateClusterRequest.java
@@ -18,9 +18,7 @@ package com.google.cloud.bigtable.admin.v2.models;
 import static com.google.cloud.bigtable.admin.v2.models.StorageType.SSD;
 
 import com.google.api.core.InternalApi;
-import com.google.bigtable.admin.v2.InstanceName;
-import com.google.bigtable.admin.v2.LocationName;
-import com.google.bigtable.admin.v2.ProjectName;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import com.google.common.base.Preconditions;
 import javax.annotation.Nonnull;
 
@@ -111,11 +109,9 @@ public final class CreateClusterRequest {
    * not meant to be used by applications.
    */
   @InternalApi
-  public com.google.bigtable.admin.v2.CreateClusterRequest toProto(ProjectName projectName) {
-    proto.setParent(InstanceName.of(projectName.getProject(), instanceId).toString());
-    proto
-        .getClusterBuilder()
-        .setLocation(LocationName.of(projectName.getProject(), zone).toString());
+  public com.google.bigtable.admin.v2.CreateClusterRequest toProto(String projectId) {
+    proto.setParent(NameUtil.formatInstanceName(projectId, instanceId));
+    proto.getClusterBuilder().setLocation(NameUtil.formatLocationName(projectId, zone));
 
     return proto.build();
   }
@@ -140,10 +136,8 @@ public final class CreateClusterRequest {
    * applications.
    */
   @InternalApi
-  com.google.bigtable.admin.v2.Cluster toEmbeddedProto(ProjectName projectName) {
-    proto
-        .getClusterBuilder()
-        .setLocation(LocationName.of(projectName.getProject(), zone).toString());
+  com.google.bigtable.admin.v2.Cluster toEmbeddedProto(String projectId) {
+    proto.getClusterBuilder().setLocation(NameUtil.formatLocationName(projectId, zone));
 
     return proto.getClusterBuilder().build();
   }

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateInstanceRequest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateInstanceRequest.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.admin.v2.models;
 
 import com.google.api.core.InternalApi;
 import com.google.bigtable.admin.v2.Instance.Type;
-import com.google.bigtable.admin.v2.ProjectName;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.util.List;
@@ -151,12 +151,11 @@ public final class CreateInstanceRequest {
    * not meant to be used by applications.
    */
   @InternalApi
-  public com.google.bigtable.admin.v2.CreateInstanceRequest toProto(ProjectName projectName) {
-    builder.setParent(projectName.toString()).clearClusters();
+  public com.google.bigtable.admin.v2.CreateInstanceRequest toProto(String projectId) {
+    builder.setParent(NameUtil.formatProjectName(projectId)).clearClusters();
 
     for (CreateClusterRequest clusterRequest : clusterRequests) {
-      builder.putClusters(
-          clusterRequest.getClusterId(), clusterRequest.toEmbeddedProto(projectName));
+      builder.putClusters(clusterRequest.getClusterId(), clusterRequest.toEmbeddedProto(projectId));
     }
 
     return builder.build();

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateTableRequest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateTableRequest.java
@@ -17,12 +17,13 @@ package com.google.cloud.bigtable.admin.v2.models;
 
 import com.google.api.core.InternalApi;
 import com.google.bigtable.admin.v2.ColumnFamily;
-import com.google.bigtable.admin.v2.InstanceName;
 import com.google.bigtable.admin.v2.Table;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
+import javax.annotation.Nonnull;
 
 /**
  * Fluent wrapper for {@link com.google.bigtable.admin.v2.CreateTableRequest}
@@ -110,10 +111,13 @@ public final class CreateTableRequest {
   }
 
   @InternalApi
-  public com.google.bigtable.admin.v2.CreateTableRequest toProto(InstanceName instanceName) {
-    Preconditions.checkNotNull(instanceName);
+  public com.google.bigtable.admin.v2.CreateTableRequest toProto(
+      @Nonnull String projectId, @Nonnull String instanceId) {
+    Preconditions.checkNotNull(projectId);
+    Preconditions.checkNotNull(instanceId);
+
     return createTableRequest
-        .setParent(instanceName.toString())
+        .setParent(NameUtil.formatInstanceName(projectId, instanceId))
         .setTable(tableRequest.build())
         .build();
   }

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/ModifyColumnFamiliesRequest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/ModifyColumnFamiliesRequest.java
@@ -16,11 +16,11 @@
 package com.google.cloud.bigtable.admin.v2.models;
 
 import com.google.api.core.InternalApi;
-import com.google.bigtable.admin.v2.InstanceName;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification;
-import com.google.bigtable.admin.v2.TableName;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
 import com.google.common.base.Preconditions;
+import javax.annotation.Nonnull;
 
 /**
  * Fluent wrapper for {@link com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest}
@@ -106,10 +106,11 @@ public final class ModifyColumnFamiliesRequest {
 
   @InternalApi
   public com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest toProto(
-      InstanceName instanceName) {
-    Preconditions.checkNotNull(instanceName);
-    String tableName =
-        TableName.of(instanceName.getProject(), instanceName.getInstance(), tableId).toString();
+      @Nonnull String projectId, @Nonnull String instanceId) {
+    Preconditions.checkNotNull(projectId, "Project id can't be null");
+    Preconditions.checkNotNull(instanceId, "Instance id can't be null");
+
+    String tableName = NameUtil.formatTableName(projectId, instanceId, tableId);
     return modFamilyRequest.setName(tableName).build();
   }
 }

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/UpdateAppProfileRequest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/UpdateAppProfileRequest.java
@@ -16,8 +16,7 @@
 package com.google.cloud.bigtable.admin.v2.models;
 
 import com.google.api.core.InternalApi;
-import com.google.bigtable.admin.v2.AppProfileName;
-import com.google.bigtable.admin.v2.ProjectName;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import com.google.cloud.bigtable.admin.v2.models.AppProfile.MultiClusterRoutingPolicy;
 import com.google.cloud.bigtable.admin.v2.models.AppProfile.RoutingPolicy;
 import com.google.cloud.bigtable.admin.v2.models.AppProfile.SingleClusterRoutingPolicy;
@@ -133,10 +132,10 @@ public final class UpdateAppProfileRequest {
    * not meant to be used by applications.
    */
   @InternalApi
-  public com.google.bigtable.admin.v2.UpdateAppProfileRequest toProto(ProjectName projectName) {
-    AppProfileName name = AppProfileName.of(projectName.getProject(), instanceId, appProfileId);
+  public com.google.bigtable.admin.v2.UpdateAppProfileRequest toProto(String projectId) {
+    String name = NameUtil.formatAppProfileName(projectId, instanceId, appProfileId);
 
-    proto.getAppProfileBuilder().setName(name.toString());
+    proto.getAppProfileBuilder().setName(name);
 
     return proto.build();
   }

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/UpdateInstanceRequest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/main/java/com/google/cloud/bigtable/admin/v2/models/UpdateInstanceRequest.java
@@ -18,9 +18,8 @@ package com.google.cloud.bigtable.admin.v2.models;
 import com.google.api.core.InternalApi;
 import com.google.bigtable.admin.v2.Instance;
 import com.google.bigtable.admin.v2.Instance.Type;
-import com.google.bigtable.admin.v2.InstanceName;
 import com.google.bigtable.admin.v2.PartialUpdateInstanceRequest;
-import com.google.bigtable.admin.v2.ProjectName;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.util.FieldMaskUtil;
@@ -97,14 +96,13 @@ public class UpdateInstanceRequest {
    * not meant to be used by applications.
    */
   @InternalApi
-  public PartialUpdateInstanceRequest toProto(ProjectName projectName) {
+  public PartialUpdateInstanceRequest toProto(String projectId) {
     // Empty field mask implies full resource replacement, which would clear all fields in an empty
     // update request.
     Preconditions.checkState(
         !builder.getUpdateMask().getPathsList().isEmpty(), "Update request is empty");
 
-    InstanceName instanceName = InstanceName.of(projectName.getProject(), instanceId);
-    builder.getInstanceBuilder().setName(instanceName.toString());
+    builder.getInstanceBuilder().setName(NameUtil.formatInstanceName(projectId, instanceId));
 
     return builder.build();
   }

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettingsTest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettingsTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.admin.v2;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.rpc.StatusCode.Code;
-import com.google.bigtable.admin.v2.ProjectName;
 import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings.Builder;
 import java.io.IOException;
 import org.junit.Test;
@@ -26,12 +25,12 @@ import org.junit.Test;
 public class BigtableInstanceAdminSettingsTest {
   @Test
   public void testProjectName() throws Exception {
-    ProjectName projectName = ProjectName.of("my-project");
-    Builder builder = BigtableInstanceAdminSettings.newBuilder().setProjectName(projectName);
+    String projectId = "my-project";
+    Builder builder = BigtableInstanceAdminSettings.newBuilder().setProjectId(projectId);
 
-    assertThat(builder.getProjectName()).isEqualTo(projectName);
-    assertThat(builder.build().getProjectName()).isEqualTo(projectName);
-    assertThat(builder.build().toBuilder().getProjectName()).isEqualTo(projectName);
+    assertThat(builder.getProjectId()).isEqualTo(projectId);
+    assertThat(builder.build().getProjectId()).isEqualTo(projectId);
+    assertThat(builder.build().toBuilder().getProjectId()).isEqualTo(projectId);
   }
 
   @Test
@@ -39,7 +38,7 @@ public class BigtableInstanceAdminSettingsTest {
     Exception actualException = null;
 
     Builder settingsBuilder = BigtableInstanceAdminSettings.newBuilder();
-    assertThat(settingsBuilder.getProjectName()).isNull();
+    assertThat(settingsBuilder.getProjectId()).isNull();
 
     try {
       settingsBuilder.build();
@@ -52,10 +51,10 @@ public class BigtableInstanceAdminSettingsTest {
 
   @Test
   public void testStubSettings() throws IOException {
-    ProjectName projectName = ProjectName.of("my-project");
+    String projectId = "my-project";
 
     BigtableInstanceAdminSettings.Builder builder =
-        BigtableInstanceAdminSettings.newBuilder().setProjectName(projectName);
+        BigtableInstanceAdminSettings.newBuilder().setProjectId(projectId);
 
     builder.stubSettings().createInstanceSettings().setRetryableCodes(Code.INVALID_ARGUMENT);
 

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientTest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientTest.java
@@ -27,13 +27,13 @@ import com.google.bigtable.admin.v2.DeleteTableRequest;
 import com.google.bigtable.admin.v2.DropRowRangeRequest;
 import com.google.bigtable.admin.v2.GcRule;
 import com.google.bigtable.admin.v2.GetTableRequest;
-import com.google.bigtable.admin.v2.InstanceName;
 import com.google.bigtable.admin.v2.ListTablesRequest;
 import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification;
 import com.google.bigtable.admin.v2.Table.View;
 import com.google.bigtable.admin.v2.TableName;
 import com.google.cloud.bigtable.admin.v2.BaseBigtableTableAdminClient.ListTablesPage;
 import com.google.cloud.bigtable.admin.v2.BaseBigtableTableAdminClient.ListTablesPagedResponse;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
@@ -57,9 +57,14 @@ import org.mockito.stubbing.Answer;
 @RunWith(MockitoJUnitRunner.class)
 public class BigtableTableAdminClientTest {
 
-  private static final InstanceName INSTANCE_NAME = InstanceName.of("my-project", "my-instance");
-  private static final TableName TABLE_NAME =
-      TableName.of(INSTANCE_NAME.getProject(), INSTANCE_NAME.getInstance(), "my-table");
+  private static final String PROJECT_ID = "my-project";
+  private static final String INSTANCE_ID = "my-instance";
+  private static final String TABLE_ID = "my-table";
+
+  private static final String PROJECT_NAME = NameUtil.formatProjectName(PROJECT_ID);
+  private static final String INSTANCE_NAME = NameUtil.formatInstanceName(PROJECT_ID, INSTANCE_ID);
+  private static final String TABLE_NAME =
+      NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID);
 
   private BigtableTableAdminClient adminClient;
   @Mock private EnhancedBigtableTableAdminStub mockStub;
@@ -86,7 +91,7 @@ public class BigtableTableAdminClientTest {
 
   @Before
   public void setUp() {
-    adminClient = BigtableTableAdminClient.create(INSTANCE_NAME, mockStub);
+    adminClient = BigtableTableAdminClient.create(PROJECT_ID, INSTANCE_ID, mockStub);
 
     Mockito.when(mockStub.createTableCallable()).thenReturn(mockCreateTableCallable);
     Mockito.when(mockStub.modifyColumnFamiliesCallable()).thenReturn(mockModifyTableCallable);
@@ -108,8 +113,8 @@ public class BigtableTableAdminClientTest {
     // Setup
     com.google.bigtable.admin.v2.CreateTableRequest expectedRequest =
         com.google.bigtable.admin.v2.CreateTableRequest.newBuilder()
-            .setParent(INSTANCE_NAME.toString())
-            .setTableId(TABLE_NAME.getTable())
+            .setParent(INSTANCE_NAME)
+            .setTableId(TABLE_ID)
             .setTable(com.google.bigtable.admin.v2.Table.getDefaultInstance())
             .build();
 
@@ -120,7 +125,7 @@ public class BigtableTableAdminClientTest {
         .thenReturn(ApiFutures.immediateFuture(expectedResponse));
 
     // Execute
-    Table result = adminClient.createTable(CreateTableRequest.of(TABLE_NAME.getTable()));
+    Table result = adminClient.createTable(CreateTableRequest.of(TABLE_ID));
 
     // Verify
     assertThat(result).isEqualTo(Table.fromProto(expectedResponse));
@@ -131,7 +136,7 @@ public class BigtableTableAdminClientTest {
     // Setup
     com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest expectedRequest =
         com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.newBuilder()
-            .setName(TABLE_NAME.toString())
+            .setName(TABLE_NAME)
             .addModifications(
                 Modification.newBuilder()
                     .setId("cf")
@@ -140,7 +145,7 @@ public class BigtableTableAdminClientTest {
 
     com.google.bigtable.admin.v2.Table fakeResponse =
         com.google.bigtable.admin.v2.Table.newBuilder()
-            .setName(TABLE_NAME.toString())
+            .setName(TABLE_NAME)
             .putColumnFamilies(
                 "cf", ColumnFamily.newBuilder().setGcRule(GcRule.getDefaultInstance()).build())
             .build();
@@ -150,8 +155,7 @@ public class BigtableTableAdminClientTest {
 
     // Execute
     Table actualResult =
-        adminClient.modifyFamilies(
-            ModifyColumnFamiliesRequest.of(TABLE_NAME.getTable()).addFamily("cf"));
+        adminClient.modifyFamilies(ModifyColumnFamiliesRequest.of(TABLE_ID).addFamily("cf"));
 
     // Verify
     assertThat(actualResult).isEqualTo(Table.fromProto(fakeResponse));
@@ -176,7 +180,7 @@ public class BigtableTableAdminClientTest {
             });
 
     // Execute
-    adminClient.deleteTable(TABLE_NAME.getTable());
+    adminClient.deleteTable(TABLE_ID);
 
     // Verify
     assertThat(wasCalled.get()).isTrue();
@@ -198,7 +202,7 @@ public class BigtableTableAdminClientTest {
         .thenReturn(ApiFutures.immediateFuture(expectedResponse));
 
     // Execute
-    Table actualResult = adminClient.getTable(TABLE_NAME.getTable());
+    Table actualResult = adminClient.getTable(TABLE_ID);
 
     // Verify
     assertThat(actualResult).isEqualTo(Table.fromProto(expectedResponse));
@@ -209,16 +213,14 @@ public class BigtableTableAdminClientTest {
     // Setup
     com.google.bigtable.admin.v2.ListTablesRequest expectedRequest =
         com.google.bigtable.admin.v2.ListTablesRequest.newBuilder()
-            .setParent(INSTANCE_NAME.toString())
+            .setParent(INSTANCE_NAME)
             .build();
 
     // 3 Tables spread across 2 pages
     List<com.google.bigtable.admin.v2.Table> expectedProtos = Lists.newArrayList();
     for (int i = 0; i < 3; i++) {
       expectedProtos.add(
-          com.google.bigtable.admin.v2.Table.newBuilder()
-              .setName(TABLE_NAME.toString() + i)
-              .build());
+          com.google.bigtable.admin.v2.Table.newBuilder().setName(TABLE_NAME + i).build());
     }
     // 2 on the first page
     ListTablesPage page0 = Mockito.mock(ListTablesPage.class);
@@ -257,7 +259,7 @@ public class BigtableTableAdminClientTest {
     // Setup
     DropRowRangeRequest expectedRequest =
         DropRowRangeRequest.newBuilder()
-            .setName(TABLE_NAME.toString())
+            .setName(TABLE_NAME)
             .setRowKeyPrefix(ByteString.copyFromUtf8("rowKeyPrefix"))
             .build();
 
@@ -276,7 +278,7 @@ public class BigtableTableAdminClientTest {
             });
 
     // Execute
-    adminClient.dropRowRange(TABLE_NAME.getTable(), "rowKeyPrefix");
+    adminClient.dropRowRange(TABLE_ID, "rowKeyPrefix");
 
     // Verify
     assertThat(wasCalled.get()).isTrue();
@@ -286,7 +288,7 @@ public class BigtableTableAdminClientTest {
   public void testAwaitReplication() {
     // Setup
     @SuppressWarnings("UnnecessaryLocalVariable")
-    TableName expectedRequest = TABLE_NAME;
+    TableName expectedRequest = TableName.parse(TABLE_NAME);
 
     final AtomicBoolean wasCalled = new AtomicBoolean(false);
 
@@ -294,14 +296,14 @@ public class BigtableTableAdminClientTest {
         .thenAnswer(
             new Answer<ApiFuture<Void>>() {
               @Override
-              public ApiFuture<Void> answer(InvocationOnMock invocationOnMock) throws Throwable {
+              public ApiFuture<Void> answer(InvocationOnMock invocationOnMock) {
                 wasCalled.set(true);
                 return ApiFutures.immediateFuture(null);
               }
             });
 
     // Execute
-    adminClient.awaitReplication(TABLE_NAME.getTable());
+    adminClient.awaitReplication(TABLE_ID);
 
     // Verify
     assertThat(wasCalled.get()).isTrue();
@@ -317,7 +319,7 @@ public class BigtableTableAdminClientTest {
         .thenReturn(ApiFutures.immediateFuture(expectedResponse));
 
     // Execute
-    boolean found = adminClient.exists(TABLE_NAME.getTable());
+    boolean found = adminClient.exists(TABLE_ID);
 
     // Verify
     assertThat(found).isTrue();
@@ -334,7 +336,7 @@ public class BigtableTableAdminClientTest {
             ApiFutures.<com.google.bigtable.admin.v2.Table>immediateFailedFuture(exception));
 
     // Execute
-    boolean found = adminClient.exists(TABLE_NAME.getTable());
+    boolean found = adminClient.exists(TABLE_ID);
 
     // Verify
     assertThat(found).isFalse();

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettingsTest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettingsTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.admin.v2;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.rpc.StatusCode.Code;
-import com.google.bigtable.admin.v2.InstanceName;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -26,14 +25,17 @@ public class BigtableTableAdminSettingsTest {
 
   @Test
   public void testInstanceName() throws IOException {
-    InstanceName instanceName = InstanceName.of("my-project", "my-instance");
-
     BigtableTableAdminSettings.Builder builder =
-        BigtableTableAdminSettings.newBuilder().setInstanceName(instanceName);
+        BigtableTableAdminSettings.newBuilder()
+            .setProjectId("my-project")
+            .setInstanceId("my-instance");
 
-    assertThat(builder.getInstanceName()).isEqualTo(instanceName);
-    assertThat(builder.build().getInstanceName()).isEqualTo(instanceName);
-    assertThat(builder.build().toBuilder().getInstanceName()).isEqualTo(instanceName);
+    assertThat(builder.getProjectId()).isEqualTo("my-project");
+    assertThat(builder.getInstanceId()).isEqualTo("my-instance");
+    assertThat(builder.build().getProjectId()).isEqualTo("my-project");
+    assertThat(builder.build().getInstanceId()).isEqualTo("my-instance");
+    assertThat(builder.build().toBuilder().getProjectId()).isEqualTo("my-project");
+    assertThat(builder.build().toBuilder().getInstanceId()).isEqualTo("my-instance");
   }
 
   @Test
@@ -51,10 +53,10 @@ public class BigtableTableAdminSettingsTest {
 
   @Test
   public void testStubSettings() throws IOException {
-    InstanceName instanceName = InstanceName.of("my-project", "my-instance");
-
     BigtableTableAdminSettings.Builder builder =
-        BigtableTableAdminSettings.newBuilder().setInstanceName(instanceName);
+        BigtableTableAdminSettings.newBuilder()
+            .setProjectId("my-project")
+            .setInstanceId("my-instance");
 
     builder.stubSettings().createTableSettings().setRetryableCodes(Code.INVALID_ARGUMENT);
 

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/models/CreateAppProfileRequestTest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/models/CreateAppProfileRequestTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.bigtable.admin.v2.AppProfile.MultiClusterRoutingUseAny;
 import com.google.bigtable.admin.v2.AppProfile.SingleClusterRouting;
 import com.google.bigtable.admin.v2.InstanceName;
-import com.google.bigtable.admin.v2.ProjectName;
 import com.google.cloud.bigtable.admin.v2.models.AppProfile.MultiClusterRoutingPolicy;
 import com.google.cloud.bigtable.admin.v2.models.AppProfile.SingleClusterRoutingPolicy;
 import org.junit.Test;
@@ -37,7 +36,7 @@ public class CreateAppProfileRequestTest {
             .setRoutingPolicy(SingleClusterRoutingPolicy.of("my-cluster", true))
             .setIgnoreWarnings(true);
 
-    assertThat(wrapper.toProto(ProjectName.of("my-project")))
+    assertThat(wrapper.toProto("my-project"))
         .isEqualTo(
             com.google.bigtable.admin.v2.CreateAppProfileRequest.newBuilder()
                 .setParent(InstanceName.of("my-project", "my-instance").toString())
@@ -59,11 +58,7 @@ public class CreateAppProfileRequestTest {
         CreateAppProfileRequest.of("my-instance", "my-profile")
             .setRoutingPolicy(MultiClusterRoutingPolicy.of());
 
-    assertThat(
-            wrapper
-                .toProto(ProjectName.of("my-project"))
-                .getAppProfile()
-                .getMultiClusterRoutingUseAny())
+    assertThat(wrapper.toProto("my-project").getAppProfile().getMultiClusterRoutingUseAny())
         .isEqualTo(MultiClusterRoutingUseAny.getDefaultInstance());
   }
 
@@ -73,7 +68,7 @@ public class CreateAppProfileRequestTest {
         CreateAppProfileRequest.of("my-instance", "my-profile")
             .setRoutingPolicy(MultiClusterRoutingPolicy.of());
 
-    assertThat(wrapper.toProto(ProjectName.of("my-project")).getAppProfile().getDescription())
+    assertThat(wrapper.toProto("my-project").getAppProfile().getDescription())
         .isEqualTo("my-profile");
   }
 }

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/models/CreateClusterRequestTest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/models/CreateClusterRequestTest.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.admin.v2.models;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.bigtable.admin.v2.ProjectName;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,12 +31,11 @@ public class CreateClusterRequestTest {
             .setType(Instance.Type.PRODUCTION)
             .addCluster("cluster1", "us-east1-c", 3, StorageType.SSD);
 
-    com.google.bigtable.admin.v2.CreateInstanceRequest actual =
-        input.toProto(ProjectName.of("my-project"));
+    com.google.bigtable.admin.v2.CreateInstanceRequest actual = input.toProto("my-project");
 
     com.google.bigtable.admin.v2.CreateInstanceRequest expected =
         com.google.bigtable.admin.v2.CreateInstanceRequest.newBuilder()
-            .setParent(ProjectName.of("my-project").toString())
+            .setParent(NameUtil.formatProjectName("my-project"))
             .setInstanceId("my-instance")
             .setInstance(
                 com.google.bigtable.admin.v2.Instance.newBuilder()
@@ -62,12 +61,11 @@ public class CreateClusterRequestTest {
             .addCluster("cluster1", "us-east1-c", 3, StorageType.SSD)
             .addCluster("cluster2", "us-east1-a", 3, StorageType.SSD);
 
-    com.google.bigtable.admin.v2.CreateInstanceRequest actual =
-        input.toProto(ProjectName.of("my-project"));
+    com.google.bigtable.admin.v2.CreateInstanceRequest actual = input.toProto("my-project");
 
     com.google.bigtable.admin.v2.CreateInstanceRequest expected =
         com.google.bigtable.admin.v2.CreateInstanceRequest.newBuilder()
-            .setParent(ProjectName.of("my-project").toString())
+            .setParent(NameUtil.formatProjectName("my-project"))
             .setInstanceId("my-instance")
             .setInstance(
                 com.google.bigtable.admin.v2.Instance.newBuilder()
@@ -99,12 +97,11 @@ public class CreateClusterRequestTest {
             .setType(Instance.Type.DEVELOPMENT)
             .addCluster("cluster1", "us-east1-c", 1, StorageType.SSD);
 
-    com.google.bigtable.admin.v2.CreateInstanceRequest actual =
-        input.toProto(ProjectName.of("my-project"));
+    com.google.bigtable.admin.v2.CreateInstanceRequest actual = input.toProto("my-project");
 
     com.google.bigtable.admin.v2.CreateInstanceRequest expected =
         com.google.bigtable.admin.v2.CreateInstanceRequest.newBuilder()
-            .setParent(ProjectName.of("my-project").toString())
+            .setParent(NameUtil.formatProjectName("my-project"))
             .setInstanceId("my-instance")
             .setInstance(
                 com.google.bigtable.admin.v2.Instance.newBuilder()
@@ -132,12 +129,11 @@ public class CreateClusterRequestTest {
             .setType(Instance.Type.DEVELOPMENT)
             .addCluster("cluster1", "us-east1-c", 1, StorageType.SSD);
 
-    com.google.bigtable.admin.v2.CreateInstanceRequest actual =
-        input.toProto(ProjectName.of("my-project"));
+    com.google.bigtable.admin.v2.CreateInstanceRequest actual = input.toProto("my-project");
 
     com.google.bigtable.admin.v2.CreateInstanceRequest expected =
         com.google.bigtable.admin.v2.CreateInstanceRequest.newBuilder()
-            .setParent(ProjectName.of("my-project").toString())
+            .setParent(NameUtil.formatProjectName("my-project"))
             .setInstanceId("my-instance")
             .setInstance(
                 com.google.bigtable.admin.v2.Instance.newBuilder()

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/models/TableAdminRequestsTest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/models/TableAdminRequestsTest.java
@@ -21,7 +21,7 @@ import com.google.bigtable.admin.v2.CreateTableRequest.Split;
 import com.google.bigtable.admin.v2.GcRule;
 import com.google.bigtable.admin.v2.InstanceName;
 import com.google.bigtable.admin.v2.Table;
-import com.google.bigtable.admin.v2.TableName;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import com.google.protobuf.ByteString;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +29,8 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class TableAdminRequestsTest {
-  private final InstanceName instanceName = InstanceName.of("project", "instance");
+  private final String PROJECT_ID = "project";
+  private final String INSTANCE_ID = "instance";
 
   @Test
   public void createTable() {
@@ -38,7 +39,7 @@ public class TableAdminRequestsTest {
             .addFamily("cf1")
             .addFamily("cf2", GCRules.GCRULES.maxVersions(1))
             .addSplit(ByteString.copyFromUtf8("c"))
-            .toProto(instanceName);
+            .toProto(PROJECT_ID, INSTANCE_ID);
 
     com.google.bigtable.admin.v2.CreateTableRequest expected =
         com.google.bigtable.admin.v2.CreateTableRequest.newBuilder()
@@ -64,9 +65,10 @@ public class TableAdminRequestsTest {
     CreateTableRequest.of(null);
   }
 
+  @SuppressWarnings("ConstantConditions")
   @Test(expected = NullPointerException.class)
   public void createTableRequiredParent() {
-    CreateTableRequest.of("tableId").toProto(null);
+    CreateTableRequest.of("tableId").toProto(null, null);
   }
 
   @Test
@@ -78,13 +80,11 @@ public class TableAdminRequestsTest {
             .addFamily("cf3")
             .updateFamily("cf1", GCRules.GCRULES.maxVersions(5))
             .dropFamily("cf3")
-            .toProto(instanceName);
+            .toProto(PROJECT_ID, INSTANCE_ID);
 
     com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest expected =
         com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.newBuilder()
-            .setName(
-                TableName.of(instanceName.getProject(), instanceName.getInstance(), "tableId")
-                    .toString())
+            .setName(NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, "tableId"))
             .addModifications(
                 com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.newBuilder()
                     .setId("cf1")
@@ -119,11 +119,11 @@ public class TableAdminRequestsTest {
 
   @Test(expected = NullPointerException.class)
   public void modifyFamiliesRequiredTableId() {
-    ModifyColumnFamiliesRequest.of(null).toProto(instanceName);
+    ModifyColumnFamiliesRequest.of(null).toProto(PROJECT_ID, INSTANCE_ID);
   }
 
   @Test(expected = NullPointerException.class)
   public void modifyFamiliesRequiredParent() {
-    ModifyColumnFamiliesRequest.of("tableId").toProto(null);
+    ModifyColumnFamiliesRequest.of("tableId").toProto(null, null);
   }
 }

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/models/UpdateAppProfileRequestTest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/models/UpdateAppProfileRequestTest.java
@@ -19,7 +19,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.bigtable.admin.v2.AppProfile.MultiClusterRoutingUseAny;
 import com.google.bigtable.admin.v2.AppProfile.SingleClusterRouting;
-import com.google.bigtable.admin.v2.ProjectName;
 import com.google.cloud.bigtable.admin.v2.models.AppProfile.SingleClusterRoutingPolicy;
 import com.google.protobuf.FieldMask;
 import org.junit.Test;
@@ -36,7 +35,7 @@ public class UpdateAppProfileRequestTest {
             .setRoutingPolicy(SingleClusterRoutingPolicy.of("my-cluster", true))
             .setIgnoreWarnings(true);
 
-    assertThat(wrapper.toProto(ProjectName.of("my-project")))
+    assertThat(wrapper.toProto("my-project"))
         .isEqualTo(
             com.google.bigtable.admin.v2.UpdateAppProfileRequest.newBuilder()
                 .setAppProfile(
@@ -70,7 +69,7 @@ public class UpdateAppProfileRequestTest {
     UpdateAppProfileRequest updateWrapper =
         UpdateAppProfileRequest.of(existingWrapper).setDescription("new description");
 
-    assertThat(updateWrapper.toProto(ProjectName.of("my-project")))
+    assertThat(updateWrapper.toProto("my-project"))
         .isEqualTo(
             com.google.bigtable.admin.v2.UpdateAppProfileRequest.newBuilder()
                 .setAppProfile(existingProto.toBuilder().setDescription("new description"))

--- a/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/models/UpdateInstanceRequestTest.java
+++ b/google-cloud-clients/google-cloud-bigtable-admin/src/test/java/com/google/cloud/bigtable/admin/v2/models/UpdateInstanceRequestTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.bigtable.admin.v2.Instance;
 import com.google.bigtable.admin.v2.Instance.Type;
 import com.google.bigtable.admin.v2.PartialUpdateInstanceRequest;
-import com.google.bigtable.admin.v2.ProjectName;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.FieldMask;
 import org.junit.Test;
@@ -36,7 +35,7 @@ public class UpdateInstanceRequestTest {
     Exception actualError = null;
 
     try {
-      input.toProto(ProjectName.of("my-project"));
+      input.toProto("my-project");
     } catch (Exception e) {
       actualError = e;
     }
@@ -49,7 +48,7 @@ public class UpdateInstanceRequestTest {
     UpdateInstanceRequest input =
         UpdateInstanceRequest.of("my-instance").setDisplayName("my display name");
 
-    PartialUpdateInstanceRequest actual = input.toProto(ProjectName.of("my-project"));
+    PartialUpdateInstanceRequest actual = input.toProto("my-project");
 
     PartialUpdateInstanceRequest expected =
         PartialUpdateInstanceRequest.newBuilder()
@@ -72,7 +71,7 @@ public class UpdateInstanceRequestTest {
                     "label1", "value1",
                     "label2", "value2"));
 
-    PartialUpdateInstanceRequest actual = input.toProto(ProjectName.of("my-project"));
+    PartialUpdateInstanceRequest actual = input.toProto("my-project");
 
     PartialUpdateInstanceRequest expected =
         PartialUpdateInstanceRequest.newBuilder()
@@ -91,7 +90,7 @@ public class UpdateInstanceRequestTest {
   public void testType() {
     UpdateInstanceRequest input = UpdateInstanceRequest.of("my-instance").setProductionType();
 
-    PartialUpdateInstanceRequest actual = input.toProto(ProjectName.of("my-project"));
+    PartialUpdateInstanceRequest actual = input.toProto("my-project");
 
     PartialUpdateInstanceRequest expected =
         PartialUpdateInstanceRequest.newBuilder()

--- a/google-cloud-clients/google-cloud-core/src/main/java/com/google/cloud/MetadataConfig.java
+++ b/google-cloud-clients/google-cloud-core/src/main/java/com/google/cloud/MetadataConfig.java
@@ -43,7 +43,7 @@ public class MetadataConfig {
 
   public static String getZone() {
     String zoneId = getAttribute("instance/zone");
-    if (zoneId.contains("/")) {
+    if (zoneId != null && zoneId.contains("/")) {
       return zoneId.substring(zoneId.lastIndexOf('/') + 1);
     }
     return zoneId;

--- a/google-cloud-clients/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/SequentialExecutorService.java
+++ b/google-cloud-clients/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/SequentialExecutorService.java
@@ -1,0 +1,227 @@
+package com.google.cloud.pubsub.v1;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.SettableApiFuture;
+import com.google.pubsub.v1.PublishResponse;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Executor;
+
+interface CancellableRunnable extends Runnable {
+  public void cancel(Throwable e);
+}
+
+/**
+ * An executor service that runs the tasks with the same key sequentially. The tasks with the same
+ * key will be run only when its predecessor has been completed while tasks with different keys can
+ * be run in parallel.
+ */
+final class SequentialExecutorService<T> {
+  private final SequentialExecutor manageableSequentialExecutor;
+  private final SequentialExecutor autoSequentialExecutor;
+
+  public SequentialExecutorService(Executor executor) {
+    this.manageableSequentialExecutor = SequentialExecutor.newManageableSequentialExecutor(executor);
+    this.autoSequentialExecutor = SequentialExecutor.newAutoSequentialExecutor(executor);
+  }
+
+  /**
+   * Runs asynchronous {@code Callable} tasks sequentially. If one of the tasks fails, other tasks
+   * with the same key that have not been executed will be cancelled.
+   */
+  public ApiFuture<T> submit(final String key, final Callable<ApiFuture> callable) {
+    final SettableApiFuture<T> future = SettableApiFuture.<T>create();
+    manageableSequentialExecutor.execute(key, new CancellableRunnable() {
+      private boolean cancelled = false;
+
+      @Override
+      public void run() {
+        if (cancelled) {
+          return;
+        }
+        try {
+          ApiFuture<T> callResult = callable.call();
+          ApiFutures.addCallback(callResult, new ApiFutureCallback<T>() {
+            @Override
+            public void onSuccess(T msg) {
+              future.set(msg);
+              manageableSequentialExecutor.resume(key);
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+              future.setException(e);
+              manageableSequentialExecutor.cancelQueuedTasks(key,
+                  new CancellationException(
+                      "Publishing cancelled since delivering previous message has been failed."));
+            }
+          });
+        } catch (Exception e) {
+
+        }
+      }
+
+      @Override
+      public void cancel(Throwable e) {
+        this.cancelled = true;
+        future.setException(e);
+      }
+    });
+    return future;
+  }
+
+  /**
+   * Runs synchronous {@code Runnable} tasks sequentially.
+   */
+  public void submit(final String key, final Runnable runnable) {
+    autoSequentialExecutor.execute(key, runnable);
+  }
+
+  /**
+   * Internal implemenation of SequentialExecutorService. Takes a serial stream of string keys and
+   * {@code Runnable} tasks, and runs the tasks with the same key sequentially. Tasks with the same
+   * key will be run only when its predecessor has been completed while tasks with different keys
+   * can be run in parallel.
+   */
+  static class SequentialExecutor {
+    // Maps keys to tasks.
+    private final Map<String, Deque<Runnable>> tasksByKey;
+    private final Executor executor;
+
+    enum TaskCompleteAction {
+      EXECUTE_NEXT_TASK,
+      WAIT_UNTIL_RESUME,
+    }
+    private TaskCompleteAction taskCompleteAction;
+
+    /**
+     * Creates a AutoSequentialExecutor which executes the next queued task automatically when the
+     * previous task has completed.
+     */
+    public static SequentialExecutor newAutoSequentialExecutor(Executor executor) {
+      return new SequentialExecutor(executor, TaskCompleteAction.EXECUTE_NEXT_TASK);
+    }
+
+    /**
+     * Creates a ManageableSequentialExecutor which allows users to decide when to execute the next
+     * queued task. The first queued task is executed immediately, but the following tasks will be
+     * executed only when {@link #resume(String)} is called explicitly.
+     */
+    public static SequentialExecutor newManageableSequentialExecutor(Executor executor) {
+      return new SequentialExecutor(executor, TaskCompleteAction.WAIT_UNTIL_RESUME);
+    }
+
+    private SequentialExecutor(Executor executor, TaskCompleteAction taskCompleteAction) {
+      this.executor = executor;
+      this.taskCompleteAction = taskCompleteAction;
+      this.tasksByKey = new HashMap<>();
+    }
+
+    public void execute(final String key, Runnable task) {
+      Deque<Runnable> newTasks;
+      synchronized (tasksByKey) {
+        newTasks = tasksByKey.get(key);
+        // If this key is already being handled, add it to the queue and return.
+        if (newTasks != null) {
+          newTasks.add(task);
+          return;
+        }
+
+        newTasks = new ConcurrentLinkedDeque();
+        newTasks.add(task);
+        tasksByKey.put(key, newTasks);
+      }
+
+      final Deque<Runnable> finalTasks = newTasks;
+      executor.execute(new Runnable() {
+        @Override
+        public void run() {
+          if (taskCompleteAction.equals(TaskCompleteAction.EXECUTE_NEXT_TASK)) {
+            invokeCallbackAndExecuteNext(key, finalTasks);
+          } else if (taskCompleteAction.equals(TaskCompleteAction.WAIT_UNTIL_RESUME)) {
+            invokeCallback(key, finalTasks);
+          }
+        }
+      });
+    }
+
+    /** Cancels every task in the queue assoicated with {@code key}. */
+    public void cancelQueuedTasks(final String key, Throwable e) {
+      // TODO(kimkyung-goog): Ensure execute() fails once cancelQueueTasks() has been ever invoked,
+      // so that no more tasks are scheduled.
+      synchronized (tasksByKey) {
+        final Deque<Runnable> tasks = tasksByKey.get(key);
+        if (tasks == null) {
+          return;
+        }
+        while (!tasks.isEmpty()) {
+          Runnable task = tasks.poll();
+          if (task instanceof CancellableRunnable) {
+            ((CancellableRunnable) task).cancel(e);
+          }
+        }
+      }
+    }
+
+    /** Executes the next queued task associated with {@code key}. */
+    public void resume(final String key) {
+      if (taskCompleteAction.equals(TaskCompleteAction.EXECUTE_NEXT_TASK)) {
+        // resume() is no-op since tasks are executed automatically.
+        return;
+      }
+      Deque<Runnable> tasks;
+      synchronized (tasksByKey) {
+        tasks = tasksByKey.get(key);
+        if (tasks == null) {
+          return;
+        }
+        if (tasks.isEmpty()) {
+          tasksByKey.remove(key);
+          return;
+        }
+      }
+      final Deque<Runnable> finalTasks = tasks;
+      // Run the next task.
+      executor.execute(new Runnable() {
+        @Override
+        public void run() {
+          invokeCallback(key, finalTasks);
+        }
+      });
+    }
+
+    private void invokeCallback(final String key, final Deque<Runnable> tasks) {
+      // TODO(kimkyung-goog): Check if there is a race when task list becomes empty.
+      Runnable task = tasks.poll();
+      if (task != null) {
+        task.run();
+      }
+    }
+
+    private void invokeCallbackAndExecuteNext(final String key, final Deque<Runnable> tasks) {
+      invokeCallback(key, tasks);
+      synchronized (tasksByKey) {
+        if (tasks.isEmpty()) {
+          // Note that there can be a race if a task is added to `tasks` at this point. However,
+          // tasks.add() is called only inside the block synchronized by `tasksByKey` object
+          // in the execute() function. Therefore, we are safe to remove `tasks` here. This is not
+          // optimal, but correct.
+          tasksByKey.remove(key);
+          return;
+        }
+      }
+      executor.execute(new Runnable() {
+        @Override
+        public void run() {
+          invokeCallbackAndExecuteNext(key, tasks);
+        }
+      });
+    }
+  }
+}

--- a/google-cloud-clients/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/SequentialExecutorServiceTest.java
+++ b/google-cloud-clients/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/SequentialExecutorServiceTest.java
@@ -1,0 +1,230 @@
+package com.google.cloud.pubsub.v1;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.common.collect.ImmutableList;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class SequentialExecutorServiceTest {
+  private final ExecutorProvider executorProvider =
+      InstantiatingExecutorProvider.newBuilder()
+          .setExecutorThreadCount(5 * Runtime.getRuntime().availableProcessors())
+          .build();
+
+  static class AsyncTaskCallable implements Callable<ApiFuture> {
+    boolean isCalled = false;
+    SettableApiFuture<String> result = SettableApiFuture.<String>create();
+
+    @Override
+    public ApiFuture<String> call() {
+      isCalled = true;
+      return result;
+    }
+
+    public boolean isCalled() {
+      return isCalled;
+    }
+
+    public void finishWithError(Throwable e) {
+      result.setException(e);
+    }
+
+    public void finish() {
+      result.set("ok");
+    }
+  }
+
+  @Test
+  public void testExecutorRunsNextTaskWhenPrevResponseReceived() throws Exception {
+    SequentialExecutorService<String> sequentialExecutorService =
+        new SequentialExecutorService<>(executorProvider.getExecutor());
+    AsyncTaskCallable callable1 = new AsyncTaskCallable();
+    AsyncTaskCallable callable2 = new AsyncTaskCallable();
+    AsyncTaskCallable callable3 = new AsyncTaskCallable();
+
+    ApiFuture<String> result1 = sequentialExecutorService.submit("key", callable1);
+    ApiFuture<String> result2 = sequentialExecutorService.submit("key", callable2);
+    ApiFuture<String> result3 = sequentialExecutorService.submit("key", callable3);
+
+    Thread.sleep(1000);
+    assertFalse(callable2.isCalled());
+    assertFalse(callable3.isCalled());
+    callable1.finish();
+    assertEquals("ok", result1.get());
+
+    assertFalse(callable3.isCalled());
+    callable2.finish();
+    assertEquals("ok", result2.get());
+
+    callable3.finish();
+    assertEquals("ok", result3.get());
+  }
+
+  @Test
+  public void testExecutorRunsDifferentKeySimultaneously() throws Exception {
+    SequentialExecutorService<String> sequentialExecutorService =
+        new SequentialExecutorService<>(executorProvider.getExecutor());
+    AsyncTaskCallable callable1 = new AsyncTaskCallable();
+    AsyncTaskCallable callable2 = new AsyncTaskCallable();
+    AsyncTaskCallable callable3 = new AsyncTaskCallable();
+
+    // Submit three tasks (two tasks with "key", and one task with "key2").
+    ApiFuture<String> result1 = sequentialExecutorService.submit("key", callable1);
+    ApiFuture<String> result2 = sequentialExecutorService.submit("key", callable2);
+    ApiFuture<String> result3 = sequentialExecutorService.submit("key2", callable3);
+
+    // The task associated with "key2" can be run in parallel with other tasks with "key".
+    callable3.finish();
+    assertEquals("ok", result3.get());
+
+    // Sleep some time to give the test a chance to fail. Verify that the second task has not been
+    // executed while the main thread is slpeeing.
+    Thread.sleep(100);
+    assertFalse(callable2.isCalled());
+    // Complete the first task.
+    callable1.finish();
+    assertEquals("ok", result1.get());
+    // Now, the second task can be executed.
+    callable2.finish();
+    assertEquals("ok", result2.get());
+  }
+
+  @Test
+  public void testExecutorCancelsAllTasksWhenOneFailed() throws Exception {
+    SequentialExecutorService<String> sequentialExecutorService =
+        new SequentialExecutorService<>(executorProvider.getExecutor());
+    AsyncTaskCallable callable1 = new AsyncTaskCallable();
+    AsyncTaskCallable callable2 = new AsyncTaskCallable();
+    AsyncTaskCallable callable3 = new AsyncTaskCallable();
+
+    ApiFuture<String> result1 = sequentialExecutorService.submit("key", callable1);
+    ApiFuture<String> result2 = sequentialExecutorService.submit("key", callable2);
+    ApiFuture<String> result3 = sequentialExecutorService.submit("key", callable3);
+
+    Throwable failure = new Exception("failure");
+    callable1.finishWithError(failure);
+    // The failed task throws an exception that contains the cause of the failure.
+    try {
+      result1.get();
+      fail("Should have thrown an ExecutionException");
+    } catch (ExecutionException e) {
+      assertEquals(failure, e.getCause());
+    }
+    // Other tasks in the queue are expected to fail with a CancellationException.
+    for (ApiFuture<String> result : ImmutableList.of(result2, result3)) {
+      try {
+        result.get();
+        fail("Should have thrown an ExecutionException");
+      } catch (ExecutionException e) {
+        assertThat(e.getCause()).isInstanceOf(CancellationException.class);
+      }
+    }
+  }
+
+  /**
+   * A task that sleeps {@code taskDurationMillis} milliseconds. Appends its {@code taskId} to
+   * {@code startedTasksSequence} before sleeping and appends it to {@code completedTasksSequence}
+   * when sleeping is done.
+   */
+  static class SleepingSyncTask implements Runnable {
+    private final int taskId;
+    private final long taskDurationMillis;
+    private final LinkedHashSet<Integer> startedTasksSequence;
+    private final LinkedHashSet<Integer> completedTasksSequence;
+    private final CountDownLatch remainingTasksCount;
+
+    public SleepingSyncTask(
+        int taskId,
+        long taskDurationMillis,
+        LinkedHashSet<Integer> startedTasksSequence,
+        LinkedHashSet<Integer> completedTasksSequence,
+        CountDownLatch remainingTasksCount) {
+      this.taskId = taskId;
+      this.taskDurationMillis = taskDurationMillis;
+      this.startedTasksSequence = startedTasksSequence;
+      this.completedTasksSequence = completedTasksSequence;
+      this.remainingTasksCount = remainingTasksCount;
+    }
+
+    @Override
+    public void run() {
+      if (taskId > 0) {
+        // Verify that the previous task has been completed.
+        assertTrue(startedTasksSequence.contains(taskId - 1));
+        assertTrue(completedTasksSequence.contains(taskId - 1));
+      }
+      startedTasksSequence.add(taskId);
+      try {
+        Thread.sleep(taskDurationMillis);
+      } catch (InterruptedException e) {
+        return;
+      }
+      completedTasksSequence.add(taskId);
+      remainingTasksCount.countDown();
+
+      // Verify that the next task has not been started yet.
+      assertFalse(startedTasksSequence.contains(taskId + 1));
+      assertFalse(completedTasksSequence.contains(taskId + 1));
+    }
+  }
+
+  @Test
+  public void SequentialExecutorRunsTasksAutomatically() throws Exception {
+    int numKeys = 100;
+    int numTasks = 100;
+    SequentialExecutorService sequentialExecutor =
+        new SequentialExecutorService(executorProvider.getExecutor());
+    CountDownLatch remainingTasksCount = new CountDownLatch(numKeys * numTasks);
+    // Maps keys to lists of started and completed tasks.
+    Map<String, LinkedHashSet<Integer>> startedTasks = new HashMap<>();
+    Map<String, LinkedHashSet<Integer>> completedTasks = new HashMap<>();
+
+    for (int i = 0; i < numKeys; i++) {
+      String key = "key" + i;
+      LinkedHashSet<Integer> startedTasksSequence = new LinkedHashSet<>();
+      LinkedHashSet<Integer> completedTasksSequence = new LinkedHashSet<>();
+      startedTasks.put(key, completedTasksSequence);
+      completedTasks.put(key, completedTasksSequence);
+      for (int taskId = 0; taskId < numTasks; taskId++) {
+        SleepingSyncTask task = new SleepingSyncTask(
+            taskId, 10, startedTasksSequence, completedTasksSequence, remainingTasksCount);
+        sequentialExecutor.submit(key, task);
+      }
+    }
+
+    remainingTasksCount.await();
+
+    for (int i = 0; i < numKeys; i++) {
+      LinkedHashSet<Integer> startedTasksSequence = startedTasks.get("key" + i);
+      LinkedHashSet<Integer> completedTasksSequence = completedTasks.get("key" + i);
+      // Verify that the tasks have been started and completed in order.
+      int expectedTaskId = 0;
+      Iterator<Integer> it1 = startedTasksSequence.iterator();
+      Iterator<Integer> it2 = completedTasksSequence.iterator();
+      while (it1.hasNext() && it2.hasNext()) {
+        assertEquals(expectedTaskId, it1.next().intValue());
+        assertEquals(expectedTaskId, it2.next().intValue());
+        expectedTaskId++;
+      }
+    }
+  }
+}

--- a/google-cloud-clients/google-cloud-securitycenter/synth.metadata
+++ b/google-cloud-clients/google-cloud-securitycenter/synth.metadata
@@ -1,26 +1,31 @@
 {
+  "updateTime": "2019-01-04T08:46:44.268721Z",
   "sources": [
+    {
+      "generator": {
+        "name": "artman",
+        "version": "0.16.4",
+        "dockerImage": "googleapis/artman@sha256:8b45fae963557c3299921037ecbb86f0689f41b1b4aea73408ebc50562cb2857"
+      }
+    },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5a57f0c13a358b2b15452bf2d67453774a5f6d4f",
-        "internalRef": "221837528"
+        "sha": "4930597beb4d26be020513af985506b39d4b73cd",
+        "internalRef": "227765328"
       }
-    },
+    }
+  ],
+  "destinations": [
     {
-      "git": {
-        "name": "googleapis-private",
-        "remote": "https://github.com/googleapis/googleapis-private.git",
-        "sha": "6aa8e1a447bb8d0367150356a28cb4d3f2332641",
-        "internalRef": "221340946"
-      }
-    },
-    {
-      "generator": {
-        "name": "artman",
-        "version": "0.16.0",
-        "dockerImage": "googleapis/artman@sha256:90f9d15e9bad675aeecd586725bce48f5667ffe7d5fc4d1e96d51ff34304815b"
+      "client": {
+        "source": "googleapis",
+        "apiName": "securitycenter",
+        "apiVersion": "v1beta1",
+        "language": "java",
+        "generator": "gapic",
+        "config": "google/cloud/securitycenter/artman_securitycenter_v1beta1.yaml"
       }
     }
   ]


### PR DESCRIPTION
Adding SequentialExecutorService that runs user tasks sequentially. A task is executed only when the previous task has been completed. SequentialExecutorService internally uses manageableSequentialExecutor for asynchronous task, and uses autoSequentialExecutor for synchronous task. 